### PR TITLE
switch to alpine:latest as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,15 @@
 # Usage:        docker build -t dannydirect/tinyproxy:latest .
 ###############################################################################
 
-FROM phusion/baseimage:latest
+FROM alpine:latest
 
 MAINTAINER Daniel Middleton <daniel-middleton.com>
 
-ADD run.sh /opt/docker-tinyproxy/run.sh
+RUN apk update \
+    && apk add \
+	bash \
+	tinyproxy
 
-RUN apt-get update && apt-get -y upgrade && apt-get -y install tinyproxy
+ADD run.sh /opt/docker-tinyproxy/run.sh
 
 ENTRYPOINT ["/opt/docker-tinyproxy/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@
 
 # Global vars
 PROG_NAME='DockerTinyproxy'
-PROXY_CONF='/etc/tinyproxy.conf'
+PROXY_CONF='/etc/tinyproxy/tinyproxy.conf'
 TAIL_LOG='/var/log/tinyproxy/tinyproxy.log'
 
 # Usage: screenOut STATUS message
@@ -62,7 +62,7 @@ stopService() {
     screenOut "Checking for running Tinyproxy service..."
     if [ "$(pidof tinyproxy)" ]; then
         screenOut "Found. Stopping Tinyproxy service for pre-configuration..."
-        service tinyproxy stop
+        killall tinyproxy
         checkStatus $? "Could not stop Tinyproxy service." \
                        "Tinyproxy service stopped successfully."
     else
@@ -93,6 +93,11 @@ setMiscConfig() {
                    "Set MinSpareServers - Edited $PROXY_CONF successfully."
 }
 
+enableLogFile() {
+	touch /var/log/tinyproxy/tinyproxy.log
+	sed -i -e"s,^#LogFile,LogFile," $PROXY_CONF
+}
+
 setAccess() {
     if [[ "$1" == *ANY* ]]; then
         sed -i -e"s/^Allow /#Allow /" $PROXY_CONF
@@ -107,7 +112,7 @@ setAccess() {
 
 startService() {
     screenOut "Starting Tinyproxy service..."
-    service tinyproxy start
+    /usr/sbin/tinyproxy
     checkStatus $? "Could not start Tinyproxy service." \
                    "Tinyproxy service started successfully."
 }
@@ -132,6 +137,8 @@ stopService
 export rawRules="$@" && parsedRules=$(parseAccessRules $rawRules) && unset rawRules
 # Set ACL in Tinyproxy config
 setAccess $parsedRules
+# Enable log to file
+enableLogFile
 # Start Tinyproxy
 startService
 # Tail Tinyproxy log


### PR DESCRIPTION
With usage of alpine:latest we can save more than 300 MB image size.

REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
docker-tiny-proxy       latest              f640f2a9f9b0        13 minutes ago      9.1 MB
dannydirect/tinyproxy   latest              56525174b96c        20 months ago       318 MB

Signed-off-by: Silvio Fricke silvio.fricke@gmail.com
