### PR TITLE
Rebuild against 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,14 @@
 # Usage:        docker build -t dannydirect/tinyproxy:latest .
 ###############################################################################
 
-FROM alpine:latest
+FROM alpine:3.7
 
-MAINTAINER Daniel Middleton <daniel-middleton.com>
+MAINTAINER Daniel Middleton <monokal.io>
 
-RUN apk update \
-    && apk add \
+RUN apk add --no-cache \
 	bash \
 	tinyproxy
 
-ADD run.sh /opt/docker-tinyproxy/run.sh
+COPY run.sh /opt/docker-tinyproxy/run.sh
 
 ENTRYPOINT ["/opt/docker-tinyproxy/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@
 
 # Global vars
 PROG_NAME='DockerTinyproxy'
-PROXY_CONF='/etc/tinyproxy.conf'
+PROXY_CONF='/etc/tinyproxy/tinyproxy.conf'
 TAIL_LOG='/var/log/tinyproxy/tinyproxy.log'
 
 # Usage: screenOut STATUS message


### PR DESCRIPTION
- Pinned the Alpine version
- Updated MAINTAINER domain
- Used `--no-cache`
- Use COPY as per https://github.com/hadolint/hadolint/wiki/DL3020

The new build is 3MB

Made this PR mostly because the current build is 124MB and really old.

You can try it out by running [`captn3m0/tinyproxy`](https://cloud.docker.com/swarm/captn3m0/repository/registry-1.docker.io/captn3m0/tinyproxy)