### PR TITLE
adjust touch location to avoid blocking the output of tinyproxy log

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -94,7 +94,6 @@ setMiscConfig() {
 }
 
 enableLogFile() {
-	touch /var/log/tinyproxy/tinyproxy.log
 	sed -i -e"s,^#LogFile,LogFile," $PROXY_CONF
 }
 
@@ -118,6 +117,7 @@ startService() {
 }
 
 tailLog() {
+    touch /var/log/tinyproxy/tinyproxy.log
     screenOut "Tailing Tinyproxy log..."
     tail -f $TAIL_LOG
     checkStatus $? "Could not tail $TAIL_LOG" \


### PR DESCRIPTION
It (touch in enableFileLog) will block outputing tinyproxy log. That is to say, only screenOut message can be seen.
I have no idea about the real reason, but after the change, the issue is fixed.
